### PR TITLE
10_mate-wayland.gschema.override: Fix Menta theme name

### DIFF
--- a/data/10_mate-wayland.gschema.override
+++ b/data/10_mate-wayland.gschema.override
@@ -2,7 +2,7 @@
 button-layout='menu:minimize,maximize,close'
 
 [org.gnome.desktop.interface:MATE]
-gtk-theme='menta'
+gtk-theme='Menta'
 icon-theme='mate'
 overlay-scrolling=false
 


### PR DESCRIPTION
See https://github.com/mate-desktop/mate-desktop/blob/v1.28.0/schemas/org.mate.interface.gschema.xml#L64

Before:
<img src="https://github.com/mate-desktop/mate-wayland-session/assets/20080233/80b427a3-d5dd-4b8d-a296-d2e2f0ce4b06" width=50%>

After:
<img src="https://github.com/mate-desktop/mate-wayland-session/assets/20080233/f28ec9a3-14b1-4b03-a26f-a50c2c49941c" width=50%>



