### PR TITLE
Ensure wayfire.ini is writable after copying

### DIFF
--- a/session/mate-wayland.sh
+++ b/session/mate-wayland.sh
@@ -11,6 +11,8 @@ create_initial_config()
     else
         #User has not configured wayfire. Look for the default .ini file where the package manager put it 
         cp /usr/share/doc/wayfire/examples/wayfire.ini /home/$USER/.config/mate/wayfire.ini
+        #Ensure the file is writable as we try to alter it later
+        chmod u+w /home/$USER/.config/mate/wayfire.ini
         #Don't use wobbly windows by default, users can readily enable them with wcm
         sed -i '/  wobbly \\/d' /home/$USER/.config/mate/wayfire.ini
 


### PR DESCRIPTION
This fixes a NixOS specific issue.

On NixOS, packages are immutable so the wayfire.ini file would
have 0444 mode when copied. As a result, further modifications
won't work.

Doing an extra `chmod u+w` to workaround the issue.