### PR TITLE
Shellcheck is now happy with both scripts from session directory

### DIFF
--- a/session/mate-wayland-components.sh
+++ b/session/mate-wayland-components.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #make sure we can find anything normally installed in libexec even if installed elsewhere
-export PATH=$PATH:/usr/local/libexec:/usr/libexec
+export PATH="$PATH:/usr/local/libexec:/usr/libexec"
 
 #Set up dbus
 
@@ -13,8 +13,8 @@ hash dbus-update-activation-environment 2>/dev/null && dbus-update-activation-en
 (pgrep "wayfire"
 while true; do
 mate-panel
-pgrep "wayfire"
-if [ $? -ne 0  ]; then
+
+if ! pgrep "wayfire" ; then
        break
 fi
 done) &
@@ -22,8 +22,8 @@ done) &
 (pgrep "wayfire"
 while true; do
 polkit-mate-authentication-agent-1
-pgrep "wayfire"
-if [ $? -ne 0  ]; then
+
+if ! pgrep "wayfire" ; then
        break
 fi
 done) &
@@ -31,8 +31,8 @@ done) &
 (pgrep "wayfire"
 while  true; do
 mate-notification-daemon
-pgrep "wayfire"
-if [ $? -ne 0  ]; then
+
+if ! pgrep "wayfire" ; then
        break
 fi
 done) &
@@ -40,8 +40,8 @@ done) &
 (pgrep "wayfire"
 while  true; do
 GDK_BACKEND=x11 mate-settings-daemon
-pgrep "wayfire"
-if [ $? -ne 0  ]; then
+
+if ! pgrep "wayfire" ; then
        break
 fi
 done) &
@@ -49,20 +49,20 @@ done) &
 (pgrep "wayfire"
 while  true; do
 caja -n --force-desktop
-pgrep "wayfire"
-if [ $? -ne 0  ]; then
+
+if ! pgrep "wayfire" ; then
        break
 fi
 done) &
 
 #Programs to start once (if we have them), matching Xorg behavior
 nm-applet --indicator &
-cat /usr/bin/blueman-applet > /dev/null
-if [ $? -eq 0  ]; then
+
+if ! cat /usr/bin/blueman-applet > /dev/null ; then
     blueman-applet &
 fi
-cat /usr/bin/gnome-keyring-daemon > /dev/null
-if [ $? -eq 0  ]; then
+
+if ! cat /usr/bin/gnome-keyring-daemon > /dev/null ; then
     gnome-keyring-daemon --start --components=pkcs11 &
     #Run the last process in the foreground to ensure a normal session exit
     gnome-keyring-daemon --start --components=ssh 

--- a/session/mate-wayland.sh
+++ b/session/mate-wayland.sh
@@ -2,63 +2,61 @@
 
 create_initial_config()
     {
-    mkdir -p /home/$USER/.config/mate
+    mkdir -p "/home/$USER/.config/mate"
 
     #Find any existing wayfire.ini file
-    if [ -e  /home/$USER/.config/wayfire.ini ]; then
+    if [ -e  "/home/$USER/.config/wayfire.ini" ]; then
         #User has configured wayfire, use their file and existing customizations
-        cp /home/$USER/.config/wayfire.ini /home/$USER/.config/mate/wayfire.ini
+        cp "/home/$USER/.config/wayfire.ini" "/home/$USER/.config/mate/wayfire.ini"
     else
         #User has not configured wayfire. Look for the default .ini file where the package manager put it 
-        cp /usr/share/doc/wayfire/examples/wayfire.ini /home/$USER/.config/mate/wayfire.ini
+        cp /usr/share/doc/wayfire/examples/wayfire.ini "/home/$USER/.config/mate/wayfire.ini"
         #Ensure the file is writable as we try to alter it later
-        chmod u+w /home/$USER/.config/mate/wayfire.ini
+        chmod u+w "/home/$USER/.config/mate/wayfire.ini"
         #Don't use wobbly windows by default, users can readily enable them with wcm
-        sed -i '/  wobbly \\/d' /home/$USER/.config/mate/wayfire.ini
+        sed -i '/  wobbly \\/d' "/home/$USER/.config/mate/wayfire.ini"
 
         #Default to using firedecor and the menta theme if we have firedecor installed
         if [ -e  /usr/lib/x86_64-linux-gnu/wayfire/libfiredecor.so ]; then
             cat /usr/share/doc/wayfire/examples/wayfire.ini /usr/share/doc/firedecor/firedecor.config \
-            > /home/$USER/.config/mate/wayfire.ini
-            sed -i 's/decoration \\.*/firedecor \\/' /home/$USER/.config/mate/wayfire.ini
-            sed -i '/  wobbly \\/d' /home/$USER/.config/mate/wayfire.ini
+            > "/home/$USER/.config/mate/wayfire.ini"
+            sed -i 's/decoration \\.*/firedecor \\/' "/home/$USER/.config/mate/wayfire.ini"
+            sed -i '/  wobbly \\/d' "/home/$USER/.config/mate/wayfire.ini"
         fi
 
         if [ -e  /usr/lib/wayfire/libfiredecor.so ]; then
             cat /usr/share/doc/wayfire/examples/wayfire.ini /usr/share/doc/firedecor/firedecor.config \
-            > /home/$USER/.config/mate/wayfire.ini
-            sed -i 's/decoration \\.*/firedecor \\/' /home/$USER/.config/mate/wayfire.ini
-            sed -i '/  wobbly \\/d' /home/$USER/.config/mate/wayfire.ini
+            > "/home/$USER/.config/mate/wayfire.ini"
+            sed -i 's/decoration \\.*/firedecor \\/' "/home/$USER/.config/mate/wayfire.ini"
+            sed -i '/  wobbly \\/d' "/home/$USER/.config/mate/wayfire.ini"
         fi
         #Check /usr/local for installs of firedecor as well
         if [ -e  /usr/local/lib/x86_64-linux-gnu/wayfire/libfiredecor.so ]; then
             cat /usr/local/share/doc/wayfire/examples/wayfire.ini /usr/local/share/doc/firedecor/firedecor.config \
-            > /home/$USER/.config/mate/wayfire.ini
-            sed -i 's/decoration \\.*/firedecor \\/' /home/$USER/.config/mate/wayfire.ini
-            sed -i '/  wobbly \\/d' /home/$USER/.config/mate/wayfire.ini
+            > "/home/$USER/.config/mate/wayfire.ini"
+            sed -i 's/decoration \\.*/firedecor \\/' "/home/$USER/.config/mate/wayfire.ini"
+            sed -i '/  wobbly \\/d' "/home/$USER/.config/mate/wayfire.ini"
         fi
 
         if [ -e  /usr/local/lib/wayfire/libfiredecor.so ]; then
             cat /usr/local/share/doc/wayfire/examples/wayfire.ini /usr/local/share/doc/firedecor/firedecor.config \
-            > /home/$USER/.config/mate/wayfire.ini
-            sed -i 's/decoration \\.*/firedecor \\/' /home/$USER/.config/mate/wayfire.ini
-            sed -i '/  wobbly \\/d' /home/$USER/.config/mate/wayfire.ini
+            > "/home/$USER/.config/mate/wayfire.ini"
+            sed -i 's/decoration \\.*/firedecor \\/' "/home/$USER/.config/mate/wayfire.ini"
+            sed -i '/  wobbly \\/d' "/home/$USER/.config/mate/wayfire.ini"
         fi
     fi
 
     #Add mate-wayland-components.sh to wayfire startup programs and set sane session defaults
-    grep "mate-wayland-components" /home/$USER/.config/mate/wayfire.ini
-
-    if [ $? -ne 0  ]; then
-        sed -i '/autostart]/a mate = mate-wayland-components.sh' /home/$USER/.config/mate/wayfire.ini
+    if ! grep "mate-wayland-components" "/home/$USER/.config/mate/wayfire.ini" ; then
+        sed -i '/autostart]/a mate = mate-wayland-components.sh' "/home/$USER/.config/mate/wayfire.ini"
         #do not start wayfire's default shell if installed
-        sed -i 's/autostart_wf_shell = true.*/autostart_wf_shell = false/' /home/$USER/.config/mate/wayfire.ini
+        sed -i 's/autostart_wf_shell = true.*/autostart_wf_shell = false/' "/home/$USER/.config/mate/wayfire.ini"
         #DO start the background though
-        sed -i '/autostart]/a background = wf-background' /home/$USER/.config/mate/wayfire.ini
+        sed -i '/autostart]/a background = wf-background' "/home/$USER/.config/mate/wayfire.ini"
         #Use server-side decoration (SSD) by default as CSD is broken with caja
-        sed -i 's/preferred_decoration_mode = client.*/preferred_decoration_mode = server/' /home/$USER/.config/mate/wayfire.ini
+        sed -i 's/preferred_decoration_mode = client.*/preferred_decoration_mode = server/' "/home/$USER/.config/mate/wayfire.ini"
         #Use wayfire's workaround to disable forcing all dialogs to modal
-        sed -i 's/all_dialogs_modal = true.*/all_dialogs_modal = false/' /home/$USER/.config/mate/wayfire.ini
+        sed -i 's/all_dialogs_modal = true.*/all_dialogs_modal = false/' "/home/$USER/.config/mate/wayfire.ini"
     fi
 
     return 0
@@ -67,7 +65,7 @@ create_initial_config()
 check_config_file()
 
     {
-    if [ -e  /home/$USER/.config/mate/wayfire.ini ]; then
+    if [ -e  "/home/$USER/.config/mate/wayfire.ini" ]; then
         #If we have already configured wayfire for MATE do not alter the file
         return 0
     else
@@ -85,5 +83,5 @@ check_config_file
 export XDG_CURRENT_DESKTOP="MATE"
 
 #Start the compositor
-wayfire -c /home/$USER/.config/mate/wayfire.ini
+wayfire -c "/home/$USER/.config/mate/wayfire.ini"
 


### PR DESCRIPTION
I think it is great when the code is well formatted and satisfies all linter/checker recommendations.
Now shellcheck is happy with both scripts from *session* directory.